### PR TITLE
Appropriate defaults for IdleMaxAge and IdleConnectionTestPeriod in Bone...

### DIFF
--- a/activerecord/src/main/scala/ActiveRecordConfig.scala
+++ b/activerecord/src/main/scala/ActiveRecordConfig.scala
@@ -114,6 +114,8 @@ class DefaultConfig(
   lazy val maxConnectionsPerPartition = getInt("maxConnectionsPerPartition")
   lazy val minConnectionsPerPartition = getInt("minConnectionsPerPartition")
   lazy val maxConnectionAge = getInt("maxConnectionAge").getOrElse(0).toLong
+  lazy val idleMaxAge = getInt("idleMaxAge").getOrElse(60).toLong
+  lazy val idleConnectionTestPeriod = getInt("idleConnectionTestPeriod").getOrElse(30).toLong
 
   lazy val adapter: DatabaseAdapter = adapter(driverClass)
   def classLoader: ClassLoader = Thread.currentThread.getContextClassLoader
@@ -133,6 +135,8 @@ class DefaultConfig(
     maxConnectionsPerPartition.foreach(conf.setMaxConnectionsPerPartition)
     minConnectionsPerPartition.foreach(conf.setMinConnectionsPerPartition)
     conf.setMaxConnectionAgeInSeconds(maxConnectionAge)
+    conf.setIdleMaxAgeInSeconds(idleMaxAge)
+    conf.setIdleConnectionTestPeriodInSeconds(idleConnectionTestPeriod)
     new BoneCP(conf)
   }
 


### PR DESCRIPTION
Following fix eliminates issue #49 by setting non-zero values for IdleMaxAge and IdleConnectionTestPeriod. 
This will force BoneCP to wait IdleMaxAge seconds before marking connection as idle and connection is  likely to be reused. If IdleMaxAge is set to zero, BoneCP marks connection as Idle instantly after query execution and will not reuse this connection or close it until maxConnectionAge is expired in which case it is pretty easy to exhaust connection pool of any size. 
