### PR TITLE
Open up dsl for customization by lib users

### DIFF
--- a/activerecord/src/main/scala/packages.scala
+++ b/activerecord/src/main/scala/packages.scala
@@ -2,7 +2,7 @@ package com.github.aselab.activerecord
 
 import scala.language.experimental.macros
 
-object dsl extends org.squeryl.PrimitiveTypeMode
+trait dsl extends org.squeryl.PrimitiveTypeMode
   with inner.Annotations with inner.DSL with inner.Types with io.JsonImplicits {
   val optionUUIDTEF = PrimitiveTypeSupport.optionUUIDTEF
   val optionBooleanTEF = PrimitiveTypeSupport.optionBooleanTEF


### PR DESCRIPTION
This change will allow users to extend custom needed functionality to the dsl (e. g. squeryl custom field types to support JodaTime)