### PR TITLE
Adds a reload method to activeRecordBase

### DIFF
--- a/activerecord/src/main/scala/ActiveRecord.scala
+++ b/activerecord/src/main/scala/ActiveRecord.scala
@@ -57,6 +57,10 @@ trait ActiveRecordBase[T] extends CRUDable with ActiveModel with ActiveRecord.As
     this
   }
 
+  def reload: Option[this.type] = {
+    recordCompanion.find(id)
+  }
+
   protected def doCreate: Boolean = {
     recordCompanion.create(this)
     true

--- a/activerecord/src/test/scala/ActiveRecordSpec.scala
+++ b/activerecord/src/test/scala/ActiveRecordSpec.scala
@@ -338,6 +338,16 @@ object ActiveRecordSpec extends DatabaseSpecification with AutoRollback {
       m._companion mustEqual PrimitiveModel
     }
 
+    "be able to reload an object" >> {
+      val m = PrimitiveModel.all.head
+      PrimitiveModel.create(m)
+
+      m.string = "test"
+      m.int = 156
+      m.save
+      m.reload.get must beEqualTo(m)
+    }
+
     "CRUD" >> {
       val m = PrimitiveModel.newModel(5)
       val size = PrimitiveModel.all.size


### PR DESCRIPTION
In ruby's ActiveRecord I can call a #reload method on my ActiveRecord objects.  
It's just doing a Model.find(my_model.id) but It's quite handy for chaining methods.  
I just though we could add this to Scala ActiveRecord. Thoughts?